### PR TITLE
Added `hops` parameter to `Relationship`

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,11 +451,12 @@ _`Node`__ This represents an actual node in the ascii format.
 
 _`Relationship`__ This represents an relationship node in the ascii format.
 
-* The init can accept a `variable`\<String>, `direction`\<String>['in', 'out', '>', '<'], `labels`<List|String>, `min_hops`\<Number>, `max_hops`\<Number>, `properties`\<Keyword Arguments>
+* The init can accept a `variable`\<String>, `direction`\<String>['in', 'out', '>', '<'], `labels`<List|String>, `hops`\<Number>, `min_hops`\<Number>, `max_hops`\<Number>, `properties`\<Keyword Arguments>
 * Can be added to the chain by typing `.relationship`, `.rel`, `.r_`, or for directed: `.rel_out` or `.rel_in`
-* To create a variable length relationship, use `min_hops` and `max_hops`
-* To create a fixed length relationship, use either `min_hops` or `max_hops`, or set both to the same number
-
+* To create a variable length relationship (e.g. `1..3`), use `min_hops` and `max_hops`
+* To create variable length relationship with an open bound (e.g. `..3`), use `min_hops` or `max_hops`
+* To create a fixed length relationship, use `hops`
+* Using both `hops` and one of `min_hops` and `max_hops` will raise an error
 ### Property
 
 _`Property`_ objects simply allow for adding `.property` to the resulting Cypher query.
@@ -620,7 +621,7 @@ RETURN movie.title
 ```
 
 ```python
-p.Match.node('martin', name='Charlie Sheen').rel(labels='ACTED_IN', min_hops=2).node('movie', 'Movie')
+p.Match.node('martin', name='Charlie Sheen').rel(labels='ACTED_IN', hops=2).node('movie', 'Movie')
 p.Return(__.movie.__title__)
 ```
 

--- a/pypher/builder.py
+++ b/pypher/builder.py
@@ -96,7 +96,7 @@ def create_statement(name, attrs=None):
 class Param(object):
     """
     This object handles setting a named parameter for use in Pypher instances.
-    Anytime Pypher.bind_param is called, this object is created. 
+    Anytime Pypher.bind_param is called, this object is created.
 
     :param str name: The name of the parameter that will be used in place
         of a value in the resuliting Cypher string
@@ -693,7 +693,7 @@ class Label(Statement):
 
     def _set_operator(self, operator):
         if operator not in self._ALLOWED_OPERATORS:
-            raise 
+            raise
 
         self._operator = operator
 
@@ -1158,17 +1158,34 @@ class Relationship(Entity):
     _LABEL_OPERATOR = '|'
 
     def __init__(self, variable=None, labels=None, types=None, direction=None,
-                 min_hops=None, max_hops=None, **properties):
+                 hops=None, min_hops=None, max_hops=None, **properties):
         labels = types or labels
         super(Relationship, self).__init__(variable=variable, labels=labels,
             **properties)
 
         self._direction = None
         self.direction = direction
-        self.hops = list(
-            dict.fromkeys(
-                [str(h) for h in [min_hops, max_hops] if h is not None]))
-        
+
+        if hops is None:
+            if min_hops is None and max_hops is None:
+                # hops are not specified
+                self.hops = []
+            else:
+                # at least one of hops is not None
+                # empty string gets interpreted as open bound
+                # e.g. ["", 3] -> "..3" and [3, ""] -> "3.."
+                min_hops = "" if min_hops is None else str(min_hops)
+                max_hops = "" if max_hops is None else str(max_hops)
+                if min_hops == max_hops:
+                    # depcrated functionality, use hops instead
+                    self.hops = [min_hops]
+                else:
+                    self.hops = [min_hops, max_hops]
+        else:
+            if min_hops is not None or max_hops is not None:
+                raise ValueError("If 'hops' is specified, do not specify 'min_hops' or 'max_hops'")
+            self.hops = [str(hops)]
+
     @property
     def variable_length(self):
         if self.hops:

--- a/pypher/test/builder.py
+++ b/pypher/test/builder.py
@@ -317,14 +317,14 @@ class BuilderTests(unittest.TestCase):
     def test_can_add_empty_undirected_relationship_with_min_hop(self):
         p = Pypher()
         p.relationship(min_hops=1)
-        exp = '-[*1]-'
+        exp = '-[*1..]-'
 
         self.assertEqual(str(p), exp)
 
     def test_can_add_empty_undirected_relationship_with_max_hop(self):
         p = Pypher()
         p.relationship(max_hops=1)
-        exp = '-[*1]-'
+        exp = '-[*..1]-'
 
         self.assertEqual(str(p), exp)
 
@@ -341,6 +341,23 @@ class BuilderTests(unittest.TestCase):
         exp = '-[*3]-'
 
         self.assertEqual(str(p), exp)
+
+    def test_can_add_empty_undirected_relationship_with_fixed_length_hops(self):
+        p = Pypher()
+        p.relationship(hops=3)
+        exp = '-[*3]-'
+
+        self.assertEqual(str(p), exp)
+
+    def test_using_hops_and_min_hops_raises_error(self):
+        p = Pypher()
+        with self.assertRaises(ValueError):
+            p.relationship(hops=2, min_hops=3)
+
+    def test_using_hops_and_max_hops_raises_error(self):
+        p = Pypher()
+        with self.assertRaises(ValueError):
+            p.relationship(hops=2, max_hops=3)
 
     def test_can_add_empty_undirected_relationship_with_labels_and_types_but_uses_types(self):
         p = Pypher()
@@ -1600,7 +1617,7 @@ class ParamTests(unittest.TestCase):
     def test_will_allow_binding_of_pypher_instances_as_values(self):
         p = Pypher()
         p.bind_param(__.ID('x'), 'SOME_ID')
-        
+
         str(p)
         params = p.bound_params
 


### PR DESCRIPTION
As per #36 changed the `min_hops` and `max_hops` semantics and added a `hops` parameter, according to the proposal:

> A new param called `hops` for specifying a single hop number. `min_hops` and `max_hops` are reserved for specifying variable length relationships. If `hops` is specified, and one (or both) of `min_hops` and `max_hops` is specified, an error is raised. If just one of `min_hops` or `max_hops` is specified, then the range is only bounded on that side.

Also updated README to reflect the new changes and added tests (which pass).

One question for the author is if the old behavior of setting `min_hops` and `max_hops` to the same number should print a DeprecationWarning.  Right now the old behavior is unchanged.