### PR TITLE
Property attributes are enclosed in single underscores instead of dou…

### DIFF
--- a/pypher/builder.py
+++ b/pypher/builder.py
@@ -1,4 +1,5 @@
 import copy
+import re
 import sys
 import uuid
 
@@ -322,8 +323,13 @@ class Pypher(with_metaclass(_Link)):
     def __getattr__(self, attr):
         attr_low = attr.lower()
 
-        if attr_low[:2] == '__' and attr_low[-2:] == '__':
-            link = Property(name=attr.strip('__'))
+        if re.match('^__[a-z0-9]+__$', attr_low):
+            try:
+                self.__dict__.get(attr)
+            except KeyError:
+                raise AttributeError(f"'{self.__class__.__name__}' object has not attribute '{attr}'")
+        elif re.match('^_[a-z0-9]+_$', attr_low):
+            link = Property(name=attr.strip('_'))
         elif attr_low in _LINKS:
             link = _LINKS[attr_low]()
         else:

--- a/pypher/test/builder.py
+++ b/pypher/test/builder.py
@@ -144,7 +144,7 @@ class BuilderTests(unittest.TestCase):
 
     def test_can_add_one_property_underscore(self):
         p = Pypher()
-        p.__property__
+        p._property_
 
         expected = '.`property`'
         c = str(p)
@@ -162,7 +162,7 @@ class BuilderTests(unittest.TestCase):
 
     def test_can_add_two_properties_underscore(self):
         p = Pypher()
-        p.__prop1__.__prop2__
+        p._prop1_._prop2_
 
         expected = '.`prop1`.`prop2`'
         c = str(p)
@@ -171,7 +171,7 @@ class BuilderTests(unittest.TestCase):
 
     def test_can_add_two_properties_mixed(self):
         p = Pypher()
-        p.property('prop1').__prop2__
+        p.property('prop1')._prop2_
 
         expected = '.`prop1`.`prop2`'
         c = str(p)
@@ -1332,7 +1332,7 @@ class OperatorTests(unittest.TestCase):
     def test_can_bind_Rexp_arguments(self):
         p = Pypher()
         val = '".*some_val.*"'
-        p.n.__field__.Rexp(val)
+        p.n._field_.Rexp(val)
         q = str(p)
         params = p.bound_params
         exp = 'n.`field` =~ ${val}'.format(val=get_dict_key(params, val))


### PR DESCRIPTION
Changed the `__getattr__` definition in `Pypher` to fix issue https://github.com/emehrkay/Pypher/issues/47.
Properties are now recognized as attributes enclosed by single underscores instead of double underscored to avoid any interference with the Python subroutines