### PR TITLE
Remove unused `Hashable` import

### DIFF
--- a/pypher/builder.py
+++ b/pypher/builder.py
@@ -2,7 +2,7 @@ import copy
 import sys
 import uuid
 
-from collections import namedtuple, OrderedDict, Hashable
+from collections import namedtuple, OrderedDict
 
 from six import with_metaclass
 


### PR DESCRIPTION
Hello,

this import is unused within the library, and removing it adds support for python3.10