### PR TITLE
Fix syntax error when using hops with properties on relationships

### DIFF
--- a/pypher/builder.py
+++ b/pypher/builder.py
@@ -1263,7 +1263,7 @@ class Relationship(Entity):
             properties = ' ' + properties
 
         if labels or properties or hops:
-            fill = '[{labels}{properties}{hops}]'.format(labels=labels,
+            fill = '[{labels}{hops}{properties}]'.format(labels=labels,
                 properties=properties, hops=hops)
         else:
             fill = ''

--- a/pypher/test/builder.py
+++ b/pypher/test/builder.py
@@ -447,7 +447,7 @@ class BuilderTests(unittest.TestCase):
             name=name, age=age, min_hops=1, max_hops=3)
         c = str(p)
         params = p.bound_params
-        exp = '-[test:`one`|`two`|`three` {{`age`: ${a}, `name`: ${n}}}*1..3]-'.format(
+        exp = '-[test:`one`|`two`|`three`*1..3 {{`age`: ${a}, `name`: ${n}}}]-'.format(
             n=get_dict_key(params, name), a=get_dict_key(params, age))
 
         self.assertEqual(str(p), exp)


### PR DESCRIPTION
Moving hops ahead of properties when resolving relationship syntax.
Previously, Neo4J would return `neo4j.exceptions.CypherSyntaxError: Invalid input '*': expected "]"`.