### PR TITLE
Add check for pypher objects or partials beginning with a function th…

### DIFF
--- a/pypher/builder.py
+++ b/pypher/builder.py
@@ -44,6 +44,8 @@ _PREDEFINED_FUNCTIONS = [['size',], ['reverse',], ['head',], ['tail',],
     ['right',], ['trim',], ['ltrim',], ['toUpper',], ['toLower',],
     ['SPLIT', 'split',],['exists',], ['distinct', 'distinct', True],
     ['MAX', 'max'], ['labels']]
+_FUNCTIONS_RETURNING_LIST = ['collect', 'reverse', 'tail', 'labels', 'nodes', 
+    'keys', 'relationships', 'split']
 RELATIONSHIP_DIRECTIONS = {
     '-': 'undirected',
     '>': 'out',
@@ -768,6 +770,9 @@ class IN(Statement):
             args.append(value)
 
         args = ', '.join(args)
+
+        if args.split("(")[0] in _FUNCTIONS_RETURNING_LIST:
+            return 'IN {args}'.format(args=args)
 
         return 'IN [{args}]'.format(args=args)
 

--- a/pypher/test/builder.py
+++ b/pypher/test/builder.py
@@ -1758,6 +1758,13 @@ class ParamTests(unittest.TestCase):
         self.assertEqual(exp, s)
         self.assertEqual(1, len(params))
 
+    def test_in_statement_generates_correct_cypher_for_functions_returning_lists(self):
+        p = Pypher()
+        q = Pypher()
+        q.split("test1, test2", ",")
+        p.IN(q)
+
+        self.assertEqual(str(p), f'IN split(${list(p.bound_params)[0]}, ${list(p.bound_params)[1]})')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…at returns a list when generating IN statement.

Include a test case.

I think this should catch all of the predefined functions that return lists - and I think I'm correct in saying this would cover every case where a valid pypher or partial object might take this form. 

String compare on split is quite ugly but I couldn't figure out a way of reaching directly into the linked list of objects. This also won't account for any user-defined functions that return lists. However it should work for the built-in cases and I assume this isn't a burning issue given it's not come up till now. If you have any ideas for a nicer solution, I'd be happy to try and implement.